### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ pip install -r requirements.txt
 
 The following external packages are required for working with spellux:
 
-- **fuzzywuzzy** (>=0.17.0): fuzzy string matching using a modified Levenshtein distance
+- **frapidfuzz** (>=0.2.0): fuzzy string matching using a modified Levenshtein distance
 - **gensim** (>=3.8.0): processing of the word embedding model (Word2Vec)
 - **progressbar** (>=2.5): progress visualization for text processing
-- **python-Levenshtein** (>=0.12.0): addition to fuzzywuzzy to speed up evaluation
 - **spacy** (>=2.2.2): NLP including language support for Luxembourgish
 - **scikit-learn** (>=0.22.1): machine learning package used for tf-idf matching
 
@@ -121,10 +120,10 @@ mode='safe'/'model'/'norvig'/'tf-idf'/'combo'
 Specify the correction mode for processing:
 
 - **safe** mode uses only the existing correction resources (lemma list, pretrained matching dict) for correction. This increases the number of variants not found but limits the number of correction errors.
-- **model** mode uses the word embedding model for candidate evaluation. The function returns the 10 nearest neighbors for a word and evaluates the most likely candidate using string simililarity matching in *fuzzywuzzy*. This mode is very fast but sometimes does not return a candidate, especially for rare variants.
+- **model** mode uses the word embedding model for candidate evaluation. The function returns the 10 nearest neighbors for a word and evaluates the most likely candidate using string simililarity matching in *rapidfuzz*. This mode is very fast but sometimes does not return a candidate, especially for rare variants.
 - **norvig** mode uses the well-known spelling corrector written by Peter Norvig (see [norvig.com/spell-correct.html](https://norvig.com/spell-correct.html)). Here, words within max. 2 edits distance are evaluated by probability agaist a large text file (containing RTL atricle data). This method works best for typo detection. Also, it tends to be slow when processing long words.
 - **tf-idf** mode uses an ngram-based similartiy matrix for candidate evaluation based on the *TfidfVectorizer* method in *scikit-learn*. Faster than *norvig* mode, and always returns a candidate – but sometimes weird ones.
-- **combo** mode determines correction candidates based on a combination of *model*, *norvig*, and *td-idf*. The three candidates are evaluated using string simililarity matching in *fuzzywuzzy*. Given its composition of three correction processes plus evaluation, this is the slowest mode.
+- **combo** mode determines correction candidates based on a combination of *model*, *norvig*, and *td-idf*. The three candidates are evaluated using string simililarity matching in *rapidfuzz*. Given its composition of three correction processes plus evaluation, this is the slowest mode.
 
 **Note:** There is an additional **training** mode that is only available internally for development and testing purposes. So don't bother activating it. Won't work.
 
@@ -133,7 +132,7 @@ sim_ratio=75 # number between 0 and 100
 ```
 *Default setting: 75*
 
-This setting specifies the similiaty ratio for candidate correction to finetune correction – and reduce the number of clearly wrong candidates. During the evaluation of a candiate for the correction, the input string and the correction candidates are compared as for string similarity using the *fuzz.ratio()* process in *fuzzywuzzy*. If the similarity ratio lies below the defined threshold, the correction candidate is disregarded. This setting affects the correction modes *'model'/'norvig'/'tf-idf'/'combo'*.
+This setting specifies the similiaty ratio for candidate correction to finetune correction – and reduce the number of clearly wrong candidates. During the evaluation of a candiate for the correction, the input string and the correction candidates are compared as for string similarity using the *fuzz.ratio()* process in *rapidfuzz*. If the similarity ratio lies below the defined threshold, the correction candidate is disregarded. This setting affects the correction modes *'model'/'norvig'/'tf-idf'/'combo'*.
 
 ```Python
 add_matches=False/True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 # install using pip install -r requirements.txt
 
 
-fuzzywuzzy>=0.17.0
+rapidfuzz>=0.2.0
 gensim>=3.8.0
 progressbar>=2.5
-python-Levenshtein>=0.12.0
 scikit-learn>=0.22.1
 spacy>=2.2.2

--- a/spellux/normalizer.py
+++ b/spellux/normalizer.py
@@ -10,7 +10,7 @@ import string
 import json
 import operator
 from collections import Counter
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 from gensim.models import Word2Vec
 from spacy.lang.lb import Luxembourgish
 nlp = Luxembourgish()

--- a/spellux/norvig_corrector.py
+++ b/spellux/norvig_corrector.py
@@ -8,7 +8,7 @@ import os
 import re
 import math
 import string
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from collections import Counter
 
 thedir = os.path.dirname(__file__)


### PR DESCRIPTION
FuzzyWuzzy and Python-Levenshtein are both GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote rapidfuzz which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.

The results are slightly different since FuzzyWuzzy always rounds the results so you end up with full percent, while I decided to return a floating point for RapidFuzz so the precision is not thrown away by the library already, but the general calculation is exactly the same